### PR TITLE
fix: fallback for the sendStartNotification config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,5 +17,5 @@ export const LOCALE: string = config['locale'] || 'en-US';
 export const LOG_LEVEL: string = config['logLevel'] || 'info';
 export const ACCOUNTS: ACCOUNT[] = config['accounts'];
 export const TEST_NOTIFIERS: boolean = config?.['testNotifiers'];
-export const SEND_START_NOTIFICATION: string = config?.['sendStartNotification'] || true;
+export const SEND_START_NOTIFICATION: string = config?.['sendStartNotification'] ?? true;
 export const CRON_SCHEDULE: string = config?.['cronSchedule'] || '* * * * *';


### PR DESCRIPTION
Looks like something wrong happened when merging master into #3.

https://github.com/Nyrrell/tgtg-notifier/pull/3/commits/e5c6bc090ee7fb36d8fa677ee44ca683301e12a0#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R20

It should be a nullish coalescing operator on line 20 as the logical OR will fall back to `true` if `sendStartNotification` is set to `false`. Here we only want to use the default value when the config entry is `undefined`.